### PR TITLE
Fix curl installation error on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed md5sum compatibility issue for macOS in `/context-cache`
 - Replaced framework-specific directory patterns with generic ones
 - Removed hardcoded file extensions from commands
+- Fixed curl installation error on Linux - install script now downloads command files from GitHub directly instead of expecting local files
 
 ## [1.6.0] - 2025-01-25
 

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,27 @@ if [ -n "$(ls -A "$COMMANDS_DIR"/*.md 2>/dev/null)" ]; then
     cp "$COMMANDS_DIR"/*.md "$BACKUP_DIR/" 2>/dev/null || true
 fi
 
-cp "$(dirname "$0")/commands"/*.md "$COMMANDS_DIR/"
+# Download commands from GitHub
+REPO_URL="https://raw.githubusercontent.com/brennercruvinel/CCPlugins/main/commands"
+COMMANDS=(
+    "cleanproject.md"
+    "cleanup-types.md"
+    "commit.md"
+    "context-cache.md"
+    "find-todos.md"
+    "fix-imports.md"
+    "format.md"
+    "remove-comments.md"
+    "review.md"
+    "session-end.md"
+    "session-start.md"
+    "test.md"
+    "undo.md"
+)
+
+echo "📥 Downloading commands..."
+for cmd in "${COMMANDS[@]}"; do
+    curl -sSL "$REPO_URL/$cmd" -o "$COMMANDS_DIR/$cmd"
+done
 echo "✨ CCPlugins installed to $COMMANDS_DIR"
 echo "📖 Type / in Claude Code to see available commands"


### PR DESCRIPTION
## Summary
- Fixed install.sh script that was causing "cannot stat './commands/*.md'" error on Linux
- Script now downloads command files directly from GitHub instead of expecting local files
- Resolves installation issues on fresh Ubuntu systems

## Context
This bug was reported by DanishWeddingCookie on Reddit. The issue occurred because the install script expected command files to exist locally, but when run via curl, only the script itself is downloaded.

## Changes
- Modified install.sh to download each command file individually from the GitHub repository
- Updated CHANGELOG.md to document this fix

## Test plan
- [x] Tested curl installation command on fresh system
- [x] Verified all command files are downloaded correctly
- [x] Confirmed installation completes without errors

Thanks to DanishWeddingCookie for reporting this issue\!