### PR TITLE
Fix: Session path resolution for hidden folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Session Persistence for Complex Commands:**
   - `/implement`, `/refactor`, `/fix-todos`, `/scaffold`, `/security-scan`, `/fix-imports` now maintain state across Claude sessions
-  - Session files stored in project `./.claude/` directory for isolation between projects
+  - Session files stored in command-specific folders for better organization
   - Auto-resume capabilities with progress tracking and statistics
   - Intelligent plan creation before execution to ensure consistency
 
@@ -39,8 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Protects user ownership of all code changes
 
 ### Fixed
+- **Critical Path Resolution Fix (2025-08-02):**
+  - Fixed Claude LS tool not recognizing hidden folders starting with dot (.)
+  - Changed from hidden `.claude/` folder to visible command-specific folders
+  - Each command now creates its own folder: `refactor/`, `implement/`, `fix-imports/`, `security-scan/`, `scaffold/`
+  - Resolved issue where Claude would fail to find existing session files and create duplicate folders
+  - Commands now correctly resume sessions without path confusion
 - Session files now save in project directory instead of global Claude installation
-- Changed session directory from `.claude` to `claude` (no dot) to avoid path resolution issues
 - Fixed Claude interpreting relative paths incorrectly (was looking in parent directories)
 - Removed shell command dependencies for Windows compatibility
 - Corrected session persistence logic to always create plans first

--- a/README.md
+++ b/README.md
@@ -198,11 +198,26 @@ When you type a command:
 **🔄 Session Continuity**
 Commands like `/implement` and `/refactor` maintain state across Claude sessions:
 ```
-claude/                     # Note: No dot prefix, stored in project root
-├── implement_plan.md      # Current implementation progress
-├── implement_state.json   # Session state and decisions
-├── refactor_plan.md       # Refactoring roadmap
-└── refactor_state.json    # Completed transformations
+# Each command creates its own folder in project root:
+refactor/                  # Created by /refactor command
+├── plan.md               # Refactoring roadmap
+└── state.json            # Completed transformations
+
+implement/                 # Created by /implement command
+├── plan.md               # Implementation progress
+└── state.json            # Session state and decisions
+
+fix-imports/              # Created by /fix-imports command
+├── plan.md               # Import fixes plan
+└── state.json            # Resolution progress
+
+security-scan/            # Created by /security-scan command
+├── plan.md               # Vulnerabilities and fixes
+└── state.json            # Remediation progress
+
+scaffold/                 # Created by /scaffold command
+├── plan.md               # Scaffolding plan
+└── state.json            # Created files tracking
 ```
 
 **🤖 Multi-Agent Architecture**

--- a/commands/fix-imports.md
+++ b/commands/fix-imports.md
@@ -9,10 +9,10 @@ Arguments: `$ARGUMENTS` - specific paths or import patterns to fix
 I'll maintain import fixing progress:
 
 **Session Files (in current project directory):**
-- `claude/fix_imports_plan.md` - All broken imports and fixes
-- `claude/fix_imports_state.json` - Resolution progress
+- `fix-imports/plan.md` - All broken imports and fixes
+- `fix-imports/state.json` - Resolution progress
 
-**IMPORTANT:** Session files are stored in a `claude` folder (without dot) in your current project root
+**IMPORTANT:** Session files are stored in a `fix-imports` folder in your current project root
 
 **Auto-Detection:**
 - If session exists: Resume from last import
@@ -22,15 +22,15 @@ I'll maintain import fixing progress:
 ## Phase 1: Import Analysis
 
 **MANDATORY FIRST STEPS:**
-1. First, ensure `.claude` directory exists in project root
-2. Check for existing session files in `./.claude/` (NOT in parent directories)
+1. First, check for `fix-imports` directory in project root
+2. Check for existing session files in `fix-imports/` (NOT in parent directories)
 3. If no session exists:
    - Scan for all broken imports
    - Create fix plan
    - Initialize progress tracking
 4. Show import issues summary
 
-**Note:** Always look for session files in the current project's `.claude` folder, not `../../../.claude/`
+**Note:** Always look for session files in the current project's `fix-imports/` folder, not `../../../fix-imports/`
 
 I'll detect broken imports:
 
@@ -58,7 +58,7 @@ Based on analysis, I'll create resolution plan:
 4. Path recalculation
 5. Import removal if needed
 
-I'll write this plan to `fix_imports_plan.md` with:
+I'll write this plan to `fix-imports/plan.md` with:
 - Each broken import location
 - Possible resolutions
 - Confidence level

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -9,24 +9,24 @@ Arguments: `$ARGUMENTS` - URLs, paths, or descriptions of what to implement
 I'll check for existing implementation sessions to continue seamlessly:
 
 **Session Files (in current project directory):**
-- `claude/implement_plan.md` - Current implementation plan and progress
-- `claude/implement_state.json` - Session state and checkpoints
+- `implement/plan.md` - Current implementation plan and progress
+- `implement/state.json` - Session state and checkpoints
 
-**IMPORTANT:** Session files are stored in a `claude` folder (without dot) in your current project root, NOT in home directory or parent folders. If a session exists, I'll resume from the exact checkpoint. Otherwise, I'll create a new implementation plan and track progress throughout.
+**IMPORTANT:** Session files are stored in a `implement` folder in your current project root, NOT in home directory or parent folders. If a session exists, I'll resume from the exact checkpoint. Otherwise, I'll create a new implementation plan and track progress throughout.
 
 ## Phase 1: Initial Setup & Analysis
 
 **MANDATORY FIRST STEPS:**
-1. First, ensure `claude` directory exists in current working directory
+1. First, check for `implement` directory in current working directory
 2. Check for existing session files:
-   - Look for `claude/implement_state.json` in current directory
-   - Look for `claude/implement_plan.md` in current directory
+   - Look for `implement/state.json` in current directory
+   - Look for `implement/plan.md` in current directory
 3. If no session exists:
-   - Create `claude/implement_plan.md`
-   - Initialize `claude/implement_state.json`
+   - Create `implement/plan.md`
+   - Initialize `implement/state.json`
 4. Complete full analysis BEFORE any implementation
 
-**Critical:** Use `claude` (no dot) folder in current directory. Do NOT use `.claude`, `$HOME/.claude`, or any parent directory paths
+**Critical:** Use `implement` folder in current directory. Do NOT use `$HOME/implement` or any parent directory paths
 
 I'll examine what you've provided and your project structure:
 
@@ -52,7 +52,7 @@ Based on my analysis, I'll create an implementation plan:
 - Design integration approach
 - Break work into testable chunks
 
-I'll write this plan to `implement_plan.md` with clear checkpoints for continuity across sessions.
+I'll write this plan to `implement/plan.md` with clear checkpoints for continuity across sessions.
 
 ## Phase 3: Intelligent Adaptation
 
@@ -89,8 +89,8 @@ I'll implement features incrementally:
 5. Validate everything works correctly
 
 **Progress Tracking:**
-- Update `implement_plan.md` as I complete each item
-- Mark checkpoints in `implement_state.json`
+- Update `implement/plan.md` as I complete each item
+- Mark checkpoints in `implement/state.json`
 - Create meaningful git commits at logical points
 
 ## Phase 5: Quality Assurance
@@ -145,7 +145,7 @@ When you return and run `/implement` or `/implement resume`:
 
 1. **Setup session** - Create/load state files FIRST
 2. **Analyze source & target** - Complete understanding
-3. **Write plan** - Full implementation plan in `implement_plan.md`
+3. **Write plan** - Full implementation plan in `implement/plan.md`
 4. **Show plan** - Present summary before implementing
 5. **Execute systematically** - Follow plan with updates
 

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -4,17 +4,17 @@ I'll help you restructure your code systematically - preserving functionality wh
 
 Arguments: `$ARGUMENTS` - files, directories, or refactoring scope
 
-**SESSION FILES LOCATION: Always use .claude/ in current directory, NEVER ../../../.claude/ or $HOME/.claude/**
+**SESSION FILES LOCATION: Always use refactor/ folder in current directory**
 
 ## Session Intelligence
 
 I'll maintain refactoring continuity across sessions:
 
-**Session Files (hidden folder in current project):**
-- `./.claude/refactor_plan.md` - Refactoring plan with progress tracking  
-- `./.claude/refactor_state.json` - Current state and completed actions
+**Session Files (in current project):**
+- `refactor/plan.md` - Refactoring plan with progress tracking  
+- `refactor/state.json` - Current state and completed actions
 
-**IMPORTANT:** The `.claude` folder is a HIDDEN folder (starts with dot) in your CURRENT PROJECT directory. Use `./.claude/` to access it.
+**IMPORTANT:** The `refactor` folder is created in your CURRENT PROJECT directory. Use `refactor/` to access it.
 
 **Auto-Detection:**
 - If session exists: Resume from last checkpoint
@@ -24,34 +24,34 @@ I'll maintain refactoring continuity across sessions:
 **EXAMPLE OF CORRECT PATH USAGE:**
 ```
 # CORRECT - looks in current project:
-Read ./.claude/refactor_state.json
-LS ./.claude
+Read refactor/state.json
+LS refactor
 
 # WRONG - these will fail:
-Read ../../../.claude/refactor_state.json
-Read $HOME/.claude/refactor_state.json
+Read ../../../refactor/state.json
+Read $HOME/.claude/refactor/state.json
 ```
 
 ## Phase 1: Initial Setup & Analysis
 
 **MANDATORY FIRST STEPS FOR SESSION CHECK:**
 ```
-Step 1: Check for .claude directory in CURRENT directory
-Command: LS .claude
+Step 1: Check for refactor directory in CURRENT directory
+Command: LS refactor
 
-Step 2: If .claude exists, read session files:
-Command: Read .claude/refactor_state.json
-Command: Read .claude/refactor_plan.md
+Step 2: If refactor exists, read session files:
+Command: Read refactor/state.json
+Command: Read refactor/plan.md
 
 DO NOT USE THESE WRONG PATHS:
-- ../../../.claude/  (WRONG - goes up directories)
-- $HOME/.claude/  (WRONG - home directory)
-- ~/.claude/  (WRONG - home directory)
+- ../../../refactor/  (WRONG - goes up directories)
+- $HOME/refactor/  (WRONG - home directory)
+- ~/refactor/  (WRONG - home directory)
 
-ONLY USE: .claude/ (current directory)
+ONLY USE: refactor/ (current directory)
 ```
 
-**CRITICAL:** The .claude folder is a hidden folder in the CURRENT WORKING DIRECTORY where user is running the command. NOT in home, NOT in parent directories.
+**CRITICAL:** The refactor folder is created in the CURRENT WORKING DIRECTORY where user is running the command. NOT in home, NOT in parent directories.
 
 I'll examine your codebase to identify improvement opportunities:
 
@@ -78,7 +78,7 @@ Based on analysis, I'll create a structured plan:
 - **Performance**: Algorithm optimizations, caching strategies
 
 **Plan Structure:**
-I'll create a detailed plan in `refactor_plan.md`:
+I'll create a detailed plan in `refactor/plan.md`:
 - Prioritized refactoring tasks
 - Risk assessment for each change
 - Checkpoints for validation

--- a/commands/scaffold.md
+++ b/commands/scaffold.md
@@ -9,10 +9,10 @@ Arguments: `$ARGUMENTS` - feature name or component to scaffold
 I'll maintain scaffolding progress across sessions:
 
 **Session Files (in current project directory):**
-- `claude/scaffold_plan.md` - Scaffolding plan and component list
-- `claude/scaffold_state.json` - Created files and progress
+- `scaffold/plan.md` - Scaffolding plan and component list
+- `scaffold/state.json` - Created files and progress
 
-**IMPORTANT:** Session files are stored in a `claude` folder (without dot) in your current project root
+**IMPORTANT:** Session files are stored in a `scaffold` folder in your current project root
 
 **Auto-Detection:**
 - If session exists: Resume incomplete scaffolding
@@ -22,15 +22,15 @@ I'll maintain scaffolding progress across sessions:
 ## Phase 1: Pattern Discovery
 
 **MANDATORY FIRST STEPS:**
-1. First, ensure `.claude` directory exists in project root
-2. Check for existing session files in `./.claude/` (NOT in parent directories)
+1. First, check for `scaffold` directory in project root
+2. Check for existing session files in `scaffold/` (NOT in parent directories or absolute paths)
 3. If no session exists:
    - Analyze project patterns
    - Create scaffolding plan
    - Initialize progress tracking
 4. Show scaffolding preview before creating
 
-**Note:** Always look for session files in the current project's `.claude` folder, not `../../../.claude/`
+**Note:** Always look for session files in the current project's `scaffold/` folder, not `../../../scaffold/` or absolute paths
 
 I'll discover your project patterns:
 
@@ -58,7 +58,7 @@ Based on patterns, I'll create a scaffolding plan:
 - Configuration updates
 - Integration points
 
-I'll write this plan to `scaffold_plan.md` with:
+I'll write this plan to `scaffold/plan.md` with:
 - Each file to create
 - Template patterns to follow
 - Integration requirements

--- a/commands/security-scan.md
+++ b/commands/security-scan.md
@@ -9,10 +9,10 @@ Arguments: `$ARGUMENTS` - specific paths or security focus areas
 I'll maintain security remediation progress:
 
 **Session Files (in current project directory):**
-- `claude/security_scan_plan.md` - All vulnerabilities and fixes
-- `claude/security_scan_state.json` - Remediation progress
+- `security-scan/plan.md` - All vulnerabilities and fixes
+- `security-scan/state.json` - Remediation progress
 
-**IMPORTANT:** Session files are stored in a `claude` folder (without dot) in your current project root
+**IMPORTANT:** Session files are stored in a `security-scan` folder in your current project root
 
 **Auto-Detection:**
 - If session exists: Show fixed vs pending vulnerabilities
@@ -22,15 +22,15 @@ I'll maintain security remediation progress:
 ## Phase 1: Security Assessment
 
 **MANDATORY FIRST STEPS:**
-1. First, ensure `.claude` directory exists in project root
-2. Check for existing session files in `./.claude/` (NOT in parent directories)
+1. First, check for `security-scan` directory in project root
+2. Check for existing session files in `security-scan/` (NOT in parent directories or absolute paths)
 3. If no session exists:
    - Perform full security scan
    - Create vulnerability report
    - Initialize tracking
 4. Show risk summary before remediation
 
-**Note:** Always look for session files in the current project's `.claude` folder, not `../../../.claude/`
+**Note:** Always look for session files in the current project's `security-scan/` folder, not `../../../security-scan/` or absolute paths
 
 I'll analyze security across dimensions:
 
@@ -58,7 +58,7 @@ Based on findings, I'll create remediation plan:
 4. Configuration hardening
 5. Code pattern improvements
 
-I'll write this plan to `security_scan_plan.md` with:
+I'll write this plan to `security-scan/plan.md` with:
 - Each vulnerability details
 - Risk assessment
 - Remediation approach


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where session persistence was failing for 5 commands due to Claude's LS tool having issues with hidden folders.

## Problem
Commands using `.claude/` for session files were failing because:
- Claude's LS tool couldn't reliably detect hidden folders (dot-prefixed)
- This caused duplicate folder creation
- Session continuity was breaking between runs

## Solution
Changed from hidden `.claude/` folder to visible command-specific folders:
- `/refactor` → uses `refactor/`
- `/implement` → uses `implement/`
- `/fix-imports` → uses `fix-imports/`
- `/security-scan` → uses `security-scan/`
- `/scaffold` → uses `scaffold/`

## Changes
- Updated 5 command files to use visible folders
- Updated README.md Session Continuity documentation
- Added detailed fix entry to CHANGELOG.md

## Testing
Manually verified:
- Commands now correctly find existing session files
- No duplicate folder creation
- Session continuity works across Claude restarts

Fixes #49